### PR TITLE
fix: add required runtime setting and fix extension bundle version

### DIFF
--- a/go/host.json
+++ b/go/host.json
@@ -2,7 +2,7 @@
 	"version": "2.0",
 	"extensionBundle": {
 		"id": "Microsoft.Azure.Functions.ExtensionBundle",
-		"version": "[1.*, 2.0.0)"
+		"version": "[2.*, 3.0.0)"
 	},
 	"customHandler": {	    
 		"description": {

--- a/go/local.settings-example.json
+++ b/go/local.settings-example.json
@@ -1,6 +1,7 @@
 {
     "IsEncrypted": false,
     "Values": {
-      "AzureWebJobsStorage": "YOUR_STORAGE_CONNECTION_STRING"
+      "AzureWebJobsStorage": "YOUR_STORAGE_CONNECTION_STRING",
+      "FUNCTIONS_WORKER_RUNTIME": "Custom"
     }
 }


### PR DESCRIPTION
This fixes two errors after publishing, one about the ExtensionBundle not meeting the minimum version and one about the lack of the function runtime.